### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/io/github/benas/unixstream/Functions.java
+++ b/src/main/java/io/github/benas/unixstream/Functions.java
@@ -10,7 +10,11 @@ import java.util.function.Function;
  *
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
-public class Functions {
+public final class Functions {
+
+    private Functions() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     /**
      * Compact a string by removing all white spaces.

--- a/src/main/java/io/github/benas/unixstream/Predicates.java
+++ b/src/main/java/io/github/benas/unixstream/Predicates.java
@@ -9,7 +9,11 @@ import java.util.stream.Stream;
  *
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
-public class Predicates {
+public final class Predicates {
+
+    private Predicates() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     /**
      * Create a new predicate returning true when the input is not null.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat
